### PR TITLE
Fix a bug when copying some new files in sources folder when the scri…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # IntelliJ project files
 .idea
+/source/
+/target/


### PR DESCRIPTION
…pt is running, the running execution moved the new copied files directly to the error folder without process them

Delete @eaDir folder at the end in process if this folder exist in source folder to avoid unnecessary disk usage